### PR TITLE
Feature/multi messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,8 +65,11 @@ async def on_message(message):
     # if message is a command, we want to do something with it
     if message.content.lower().startswith('iris ') or (message.content.startswith('!') and not message.content.startswith('!!') and not message.content.startswith('! ') and not (message.content.endswith('!') and message.content.startswith('!'))) or message.content.startswith(f'<@!{client.user.id}> '):
         reply = process_commands(db_session, message)
-        if not reply == '':
-            await message.channel.send(reply)
+        if reply != '':
+            if isinstance(reply, str):
+                reply = [reply]
+            for r in reply:
+                await message.channel.send(r)
     # otherwise, it might contain karma so we should parse it for karma
     else:
         changes = karma_parse(message)

--- a/bot.py
+++ b/bot.py
@@ -1,13 +1,16 @@
+import asyncio
+import datetime
 import os
+from collections.abc import Iterable
+
 import discord
 import json
-import asyncio
-from utils.karma import karma_parse, karma_change
-from utils.command import process_commands
-from utils.gym import check_for_classes
+
 from creds import CREDS
 from models import db_session, User, Reminder
-import datetime
+from utils.command import process_commands
+from utils.gym import check_for_classes
+from utils.karma import karma_parse, karma_change
 
 token = CREDS['DISCORD_TOKEN']
 

--- a/commands.py
+++ b/commands.py
@@ -191,4 +191,4 @@ def e4d(db_session, message, *input_words):
     matches = [utils.e4d.match_abbr(abbr) if abbr else None
                for abbr in parsed_abbrs]
     output_lines = starmap(utils.e4d.to_output_line, zip(input_words, matches))
-    return ["\n".join(output_lines)]
+    return utils.e4d.to_output_messages(output_lines)

--- a/utils/command.py
+++ b/utils/command.py
@@ -1,4 +1,4 @@
-import discord
+from collections.abc import Iterable
 from models import Command, User
 import commands
 from inspect import getmembers, isfunction
@@ -109,18 +109,18 @@ def process_commands(db_session, message):
 
         # get highest placeholder num in args
 
-        for idx,o in enumerate(outputs):
+        for idx, o in enumerate(outputs):
+            if isinstance(o, Iterable) and not isinstance(o, str):
+                o = "\n".join(o)
+
             pos_string = '<'+str(idx+1)+'>'
-            if not pos_string in args:
+            if pos_string not in args:
                 args.append(o)
             else:
-                indices = [idx for idx,x in enumerate(args) if x == pos_string]
+                indices = [idx for idx, x in enumerate(args) if x == pos_string]
                 for ind in indices:
                     args[ind] = o
 
-        reply = func(db_session,message,*args)
-        for r in reply:
-            outputs.append(r)
-
+        reply = func(db_session, message, *args)
+        outputs.extend(reply)
     return outputs[-1]
-

--- a/utils/command.py
+++ b/utils/command.py
@@ -7,6 +7,16 @@ import re
 functions_list = [o for o in getmembers(commands) if isfunction(o[1])]
 function_names = [o[0] for o in functions_list]
 
+
+def truncate_message(msg, length=2000):
+    """ Limit message length and add truncation notice """
+    truncation_message = " *<truncated due to length>*"
+    max_message_length = 2000 - len(truncation_message)
+    if len(msg) > max_message_length:
+        return msg[:max_message_length] + truncation_message
+    return msg
+
+
 def process_commands(db_session, message):
     user = db_session.query(User).filter(User.uid == message.author.id).first()
     # here we want to split the commands up by pipes
@@ -118,9 +128,8 @@ def process_commands(db_session, message):
                 for ind in indices:
                     args[ind] = o
 
-        reply = func(db_session,message,*args)
+        reply = func(db_session, message, *args)
         for r in reply:
             outputs.append(r)
-
-    return outputs[-1]
+    return truncate_message(outputs[-1])
 

--- a/utils/e4d.py
+++ b/utils/e4d.py
@@ -1,5 +1,6 @@
 import logging
 from collections import namedtuple
+from functools import reduce
 from typing import List, Optional
 
 Abbr = namedtuple("Abbr", "first_letter length last_letter")
@@ -39,3 +40,16 @@ def to_output_line(input_word: str, matches: Optional[List[str]]) -> str:
     else:
         result_str = "_{}_".format(", ".join(matches))
     return f"**{input_word}**: {result_str}"
+
+
+def to_output_messages(output_lines: List[str]) -> List[str]:
+    def combine(a: List[str], x: str):
+        if not a or len(a[-1]) + len(x) > 2000 - 1:
+            a.append(x)
+        else:
+            a[-1] = a[-1] + f"\n{x}"
+        return a
+    messages = reduce(combine, output_lines, [])
+    if len(messages) == 1:
+        return messages
+    return [messages]


### PR DESCRIPTION
This builds on #19 to add multi-messaging, where a command can return `[["msg1","msg2"]]`. In this case, each message is truncated if necessary.